### PR TITLE
Newline error in mimetype

### DIFF
--- a/main.coffee
+++ b/main.coffee
@@ -169,7 +169,7 @@ app.get '/file/:fileid/:filename', (req, res) ->
   file = "#{__dirname}/uploads/#{req.params.fileid}"
   if /^[a-f0-9A-F]+$/.test(req.params.fileid) and fs.existsSync(file)
     db.mimetypeForFile req.params.fileid, (mimetype) ->
-      res.set 'Content-Type', mimetype
+      res.set 'Content-Type', mimetype.trim()
       res.sendfile file
   else res.send 404
 


### PR DESCRIPTION
Resolving below which is caused by newline in mimetype

_http_outgoing.js:507
    throw new TypeError('The header content contains invalid characters');
    ^

TypeError: The header content contains invalid characters
    at validateHeader (_http_outgoing.js:507:11)
    at ServerResponse.setHeader (_http_outgoing.js:511:3)
    at ServerResponse.res.setHeader (/CTFPad/node_modules/connect/lib/patch.js:134:22)
    at ServerResponse.res.set.res.header (/CTFPad/node_modules/express/lib/response.js:595:10)
    at /CTFPad/main.coffee:172:11
    at /CTFPad/database.coffee:157:60
    at Statement.<anonymous> (/CTFPad/database.coffee:175:10)
