### PR TITLE
fix crash when mimetype was not correctly read

### DIFF
--- a/main.coffee
+++ b/main.coffee
@@ -202,7 +202,7 @@ upload = (user, objtype, objid, req, res) ->
   if type != -1 and req.files.files
     mimetype = null
     process.execFile '/usr/bin/file', ['-bi', req.files.files.path], (err, stdout) ->
-      mimetype = unless err then stdout.toString()
+      mimetype = unless err then stdout.toString().trim()
       db[["addCTFFile", "addChallengeFile"][type]] objid, req.files.files.name, user.name, mimetype, (err, id) ->
         if err then res.json {success: false, error: err}
         else


### PR DESCRIPTION
Sometimes, the file command returns an additional newline after the mimetype. CTFPad does not filter this newline and thus will insert the additional newline when building the mimetype header once the bogus file is requested for download. The additional newline then crashes the pad:
```
_http_outgoing.js:494
    throw new TypeError('The header content contains invalid characters');
```
The proposed patch fixes this bug for the files that crashed our instance of CTFPad.