### PR TITLE
prevent crash

### DIFF
--- a/main.coffee
+++ b/main.coffee
@@ -321,6 +321,9 @@ wss.on 'connection', (sock) ->
             db.addChallenge ctfid, c.title, c.category, c.points
       else if msg.type and msg.type is 'modifyctf'
         for c in msg.data.challenges
+
+          if !c.points
+            c.points = 0
           if c.id
             db.modifyChallenge c.id, c.title, c.category, c.points
           else


### PR DESCRIPTION
if you edit a challenge and remove the value  for 'points', the service crashes.
because the value for points will be NULL. this will lead to a crash since the db table has the column points set to be 'NOT NULL'. 

now the points will be set to 0 (before calling the db update)